### PR TITLE
Temporal method to turn off py_trees bagging

### DIFF
--- a/py_trees/src/py_trees/ros.py
+++ b/py_trees/src/py_trees/ros.py
@@ -291,11 +291,21 @@ class BehaviourTree(trees.BehaviourTree):
         if not os.path.exists(subdir):
             os.makedirs(subdir)
 
-        # opens in ros home directory for the user
-        if 'PYTREE_BAGGING' in os.environ and int(os.environ['PYTREE_BAGGING']) == 0:
-            self.bag = None
+        # PYTREE BAGGING or NOT
+        if 'PYTREE_BAGGING' in os.environ:
+            pytree_bagging = str(os.environ['PYTREE_BAGGING'])
+            if pytree_bagging.upper() == "TRUE":
+                pytree_bagging = True
+            else:
+                pytree_bagging = False
         else:
+            pytree_bagging = False
+
+        if pytree_bagging:
+            # opens in ros home directory for the user
             self.bag = rosbag.Bag(subdir + '/behaviour_tree_' + now.strftime("%H-%M-%S") + '.bag', 'w')
+        else:
+            self.bag = None
 
         self.last_tree = py_trees_msgs.BehaviourTree()
         self.lock = threading.Lock()

--- a/py_trees/src/py_trees/ros.py
+++ b/py_trees/src/py_trees/ros.py
@@ -292,7 +292,7 @@ class BehaviourTree(trees.BehaviourTree):
             os.makedirs(subdir)
 
         # opens in ros home directory for the user
-        if int(os.environ['PYTREE_BAGGING']) == 0:
+        if 'PYTREE_BAGGING' in os.environ and int(os.environ['PYTREE_BAGGING']) == 0:
             self.bag = None
         else:
             self.bag = rosbag.Bag(subdir + '/behaviour_tree_' + now.strftime("%H-%M-%S") + '.bag', 'w')


### PR DESCRIPTION
Temporal method to turn off py_trees bagging

This change includes the codes which use environment variable 'PYTREE_BAGGING' to turn off the bagging operation of py_trees. Because the size of py_trees bag files is very big, we need a method to control bagging operation. This is not a desirable method to control bagging operation, but we need temporal and simple implementation for dealing with urgent robot software release schedule that is coming soon.
Anyway, we need to discuss this issue more after the release schedule.

Please review this PR, @hughie .